### PR TITLE
Added an import method from JSON data

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -8,7 +8,7 @@ import signal
 import subprocess
 import sys
 
-DOCKER_COMMANDS = ["up", "down", "pull", "push", "build", "logs", "run", "exec", "ls"]
+DOCKER_COMMANDS = ["up", "down", "pull", "push", "build", "logs", "run", "exec", "ls", "ps"]
 
 
 def signal_handler(_sig, _frame):

--- a/webserver/src/cli.rs
+++ b/webserver/src/cli.rs
@@ -40,4 +40,9 @@ pub enum Command {
         /// The display name for the user
         display_name: String,
     },
+    /// Import a list of users and clubs from a JSON file
+    ImportData {
+        /// Path to the file where to read the data from
+        filename: String,
+    },
 }

--- a/webserver/src/main.rs
+++ b/webserver/src/main.rs
@@ -170,7 +170,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
         Command::ImportData { filename } => {
             let body = std::fs::read_to_string(filename)?;
-            let db = Database::connect(DatabaseConfiguration::new(DB.clone())).await?;
 
             Galvyn::builder(GalvynSetup::default())
                 .register_module::<Database>(DatabaseSetup::Custom(DatabaseConfiguration::new(
@@ -180,10 +179,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 .init_modules()
                 .await?;
 
-            let tx = db.start_transaction().await?;
-            let res = import_data(tx, serde_json::from_str(&body)?).await;
-            db.close().await;
-
+            let res = import_data(serde_json::from_str(&body)?).await;
             match res {
                 Ok(_) => println!("Import completed."),
                 Err(err) => {

--- a/webserver/src/main.rs
+++ b/webserver/src/main.rs
@@ -31,7 +31,9 @@ use crate::modules::garbage_collector::GarbageCollector;
 use crate::modules::mailcow::Mailcow;
 use crate::modules::oidc::Oidc;
 use crate::tracing::opentelemetry_layer;
+use crate::utils::import::import_data;
 use crate::utils::links::Link;
+
 mod cli;
 pub mod config;
 pub mod http;
@@ -165,6 +167,30 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     return Err(err.into());
                 }
             }
+        }
+        Command::ImportData { filename } => {
+            let body = std::fs::read_to_string(filename)?;
+            let db = Database::connect(DatabaseConfiguration::new(DB.clone())).await?;
+
+            Galvyn::builder(GalvynSetup::default())
+                .register_module::<Database>(DatabaseSetup::Custom(DatabaseConfiguration::new(
+                    DB.clone(),
+                )))
+                .register_module::<Mailcow>(())
+                .init_modules()
+                .await?;
+
+            let tx = db.start_transaction().await?;
+            let res = import_data(tx, serde_json::from_str(&body)?).await;
+            db.close().await;
+
+            match res {
+                Ok(_) => println!("Import completed."),
+                Err(err) => {
+                    println!("Import failed: {err}");
+                    return Err(err);
+                }
+            };
         }
     }
 

--- a/webserver/src/models/account/club_member.rs
+++ b/webserver/src/models/account/club_member.rs
@@ -86,7 +86,7 @@ impl ClubAccount {
             .await?;
 
         guard.commit().await?;
-        Ok(model.into())
+        Ok(Self::from(model))
     }
 }
 

--- a/webserver/src/models/account/club_member.rs
+++ b/webserver/src/models/account/club_member.rs
@@ -1,12 +1,19 @@
 use galvyn::rorm;
 use galvyn::rorm::db::Executor;
 use galvyn::rorm::fields::types::MaxStr;
+use galvyn::rorm::prelude::ForeignModel;
+use galvyn::rorm::prelude::ForeignModelByField;
 use tracing::instrument;
+use uuid::Uuid;
 
 use crate::models::account::AccountUuid;
 use crate::models::account::ClubAccount;
+use crate::models::account::CreateManualClubMember;
 use crate::models::account::db::ClubAccountModel;
+use crate::models::account::db::ClubAccountModelInsert;
+use crate::models::account::db::UsernameModel;
 use crate::models::club::ClubUuid;
+use crate::models::club::db::ClubModel;
 
 impl ClubAccount {
     /// Get the account by its uuid
@@ -46,6 +53,42 @@ impl ClubAccount {
             .optional()
             .await?
             .map(Self::from))
+    }
+
+    /// Create a new club account from the provided input
+    ///
+    /// This should only be called from maintenance features like data imports.
+    /// It also creates a new `UsernameModel`. It fails when the username or email is taken.
+    #[instrument(
+        name = "ClubAccount::create_raw",
+        skip_all,
+        fields(username=%new_member.username, display_name=%new_member.display_name, email=%new_member.email)
+    )]
+    pub async fn create_raw(
+        exe: impl Executor<'_>,
+        new_member: CreateManualClubMember,
+    ) -> anyhow::Result<Self> {
+        let mut guard = exe.ensure_transaction().await?;
+
+        let username = rorm::insert(guard.get_transaction(), UsernameModel)
+            .single(&UsernameModel {
+                username: new_member.username,
+            })
+            .await?;
+
+        let model = rorm::insert(guard.get_transaction(), ClubAccountModel)
+            .single(&ClubAccountModelInsert {
+                uuid: Uuid::new_v4(),
+                username: ForeignModelByField(username.username),
+                display_name: new_member.display_name,
+                hashed_password: new_member.hashed_password,
+                email: new_member.email,
+                club: ForeignModelByField(new_member.club.0),
+            })
+            .await?;
+
+        guard.commit().await?;
+        Ok(model.into())
     }
 }
 

--- a/webserver/src/models/account/club_member.rs
+++ b/webserver/src/models/account/club_member.rs
@@ -1,7 +1,6 @@
 use galvyn::rorm;
 use galvyn::rorm::db::Executor;
 use galvyn::rorm::fields::types::MaxStr;
-use galvyn::rorm::prelude::ForeignModel;
 use galvyn::rorm::prelude::ForeignModelByField;
 use tracing::instrument;
 use uuid::Uuid;
@@ -13,7 +12,6 @@ use crate::models::account::db::ClubAccountModel;
 use crate::models::account::db::ClubAccountModelInsert;
 use crate::models::account::db::UsernameModel;
 use crate::models::club::ClubUuid;
-use crate::models::club::db::ClubModel;
 
 impl ClubAccount {
     /// Get the account by its uuid

--- a/webserver/src/models/account/mod.rs
+++ b/webserver/src/models/account/mod.rs
@@ -105,10 +105,15 @@ pub struct AccountUuid(pub Uuid);
 /// It should only be necessary to use this in maintenance features like data imports.
 #[derive(Debug, Clone)]
 pub struct CreateManualClubMember {
+    /// Username of the new club member
     pub username: MaxStr<255>,
+    /// Display name of the new club member
     pub display_name: MaxStr<255>,
+    /// Hashed password of the new club member, must be in bcrypt format
     pub hashed_password: MaxStr<255>,
+    /// E-mail address of the new club member, must end with the primary domain of the club
     pub email: MaxStr<255>,
+    /// Referenced club the new user should belong to
     pub club: ForeignModel<ClubModel>,
 }
 

--- a/webserver/src/models/account/mod.rs
+++ b/webserver/src/models/account/mod.rs
@@ -8,6 +8,7 @@ use galvyn::core::re_exports::schemars::JsonSchema;
 use galvyn::rorm;
 use galvyn::rorm::db::Executor;
 use galvyn::rorm::fields::types::MaxStr;
+use galvyn::rorm::prelude::ForeignModel;
 use galvyn::rorm::prelude::ForeignModelByField;
 use serde::Deserialize;
 use serde::Serialize;
@@ -20,6 +21,7 @@ use crate::models::account::db::AdministrativeAccountModel;
 use crate::models::account::db::ClubAccountModel;
 use crate::models::account::db::ClubAdminAccountModel;
 use crate::models::club::ClubUuid;
+use crate::models::club::db::ClubModel;
 use crate::models::credential_reset::CredentialReset;
 use crate::models::credential_reset::CredentialResetUuid;
 use crate::models::credential_reset::db::CredentialResetClubAccountModel;
@@ -98,6 +100,17 @@ pub struct ClubAccount {
 /// New-type for the account's primary key
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema)]
 pub struct AccountUuid(pub Uuid);
+
+/// Helper to create new club members, used for [`ClubAccountModelInsert`].
+/// It should only be necessary to use this in maintenance features like data imports.
+#[derive(Debug, Clone)]
+pub struct CreateManualClubMember {
+    pub username: MaxStr<255>,
+    pub display_name: MaxStr<255>,
+    pub hashed_password: MaxStr<255>,
+    pub email: MaxStr<255>,
+    pub club: ForeignModel<ClubModel>,
+}
 
 impl Account {
     /// Retrieve the account by its uuid

--- a/webserver/src/utils/import.rs
+++ b/webserver/src/utils/import.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::error::Error;
 use std::str::FromStr;
-use std::time::Duration;
+use std::sync::Arc;
 
 use bcrypt::HashParts;
 use galvyn::core::Module;
@@ -12,6 +12,7 @@ use galvyn::rorm::fields::types::MaxStr;
 use galvyn::rorm::prelude::ForeignModelByField;
 use serde::Deserialize;
 use tracing::info;
+use tracing::warn;
 
 use crate::models::account::ClubAccount;
 use crate::models::account::CreateManualClubMember;
@@ -116,37 +117,59 @@ pub async fn import_data(mut tx: Transaction, body: ImportBody) -> Result<(), Bo
             .push(new_account);
     }
 
+    // Committing the transaction here is required due to the implementation of the
+    // app_password worker, simply hope for the best and that all jobs complete
     tx.commit().await?;
     info!(
-        "Imported {} new accounts, not saved yet, preparing mailcow app password setup",
+        "Imported {} new accounts, now preparing mailcow app password setup, do not quit...",
         new_accounts.len()
     );
 
-    let mut ongoing_jobs = vec![];
+    const MAX_WORKERS: usize = 8;
+
+    // Using a semaphore for limiting max amount of concurrent workers
+    let mut join_set = tokio::task::JoinSet::new();
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_WORKERS));
     for club in &clubs {
         if !club.use_xauth {
             for new_account in new_accounts.get(&club.uuid).expect("just created earlier") {
-                // TODO: access to mailcow galvyn module also without the web server possible?
-                ongoing_jobs.push(Mailcow::global().create_app_password(new_account.email.clone()));
-                tokio::time::sleep(Duration::from_millis(200)).await; // slightly avoid overloading
+                let semaphore = semaphore.clone();
+                let email = new_account.email.clone();
+                join_set.spawn(async move {
+                    let _permit = semaphore.acquire().await.expect("never closed");
+                    let handle = Mailcow::global().create_app_password(email.clone());
+                    match handle.join().await {
+                        Ok(_) => (),
+                        Err(e) => warn!(
+                            error.display = %e,
+                            error.debug = ?e,
+                            mailbox = %email,
+                            "Failed to complete a job to update app password, continuing anyway..."
+                        ),
+                    };
+                    drop(_permit); // automatically, but for clarity
+                });
             }
         }
     }
-    info!(
-        "Waiting for the completion of {} background jobs",
-        ongoing_jobs.len()
-    );
-    while let Some(job) = ongoing_jobs.pop() {
-        if !job.is_finished() {
-            ongoing_jobs.push(job);
+
+    // Occasionally inform about ongoing/remaining jobs while awaiting all of them
+    let total_jobs = join_set.len();
+    let mut completed = 0;
+    let chunk = (total_jobs / 10).max(1);
+    while let Some(_) = join_set.join_next().await {
+        completed += 1;
+        if completed % chunk == 0 {
             info!(
-                "Waiting for the completion of {} background jobs",
-                ongoing_jobs.len()
+                completed = completed,
+                total = total_jobs,
+                "Waiting for the completion of {} background jobs...",
+                total_jobs - completed
             );
-            tokio::time::sleep(Duration::from_secs(1)).await;
         }
     }
 
+    info!("Completed import");
     Ok(())
 }
 

--- a/webserver/src/utils/import.rs
+++ b/webserver/src/utils/import.rs
@@ -1,0 +1,165 @@
+//! Utility module to allow importing data from JSON strings
+
+use std::collections::HashMap;
+use std::error::Error;
+use std::str::FromStr;
+use std::time::Duration;
+
+use bcrypt::HashParts;
+use galvyn::core::Module;
+use galvyn::rorm::db::transaction::Transaction;
+use galvyn::rorm::fields::types::MaxStr;
+use galvyn::rorm::prelude::ForeignModelByField;
+use serde::Deserialize;
+use tracing::info;
+
+use crate::models::account::ClubAccount;
+use crate::models::account::CreateManualClubMember;
+use crate::models::club::Club;
+use crate::modules::mailcow::Mailcow;
+
+/// Import users from a JSON payload
+///
+/// All clubs must exist for every user that is imported through this endpoint.
+/// If a user that should be imported here can not be matched to an existing club,
+/// the import is aborted. It expects the galvyn registry to be available with Mailcow module.
+pub async fn import_data(mut tx: Transaction, body: ImportBody) -> Result<(), Box<dyn Error>> {
+    let clubs = Club::find_all(&mut tx).await?;
+
+    // Ensure no duplicate usernames or email addresses across all existing members
+    // (it would still break later if collided with the name of a superadmin)
+    for club in &clubs {
+        let members = club
+            .members_page(&mut tx, u32::MAX as u64, 0, None)
+            .await?
+            .items;
+
+        let mut email_taken = vec![];
+        let mut username_taken = vec![];
+        for club_member in &members {
+            for new_member in &body.members {
+                if club_member.email == new_member.email {
+                    email_taken.push(club_member.email.clone());
+                }
+                if club_member.username == new_member.username {
+                    username_taken.push(club_member.username.clone());
+                }
+            }
+        }
+
+        if !email_taken.is_empty() {
+            return Err(format!(
+                "Club {} has some emails already taken: {:?}",
+                club.name,
+                email_taken.join(", ")
+            )
+            .into());
+        }
+        if !username_taken.is_empty() {
+            return Err(format!(
+                "Club {} has some usernames already taken: {:?}",
+                club.name,
+                username_taken.join(", ")
+            )
+            .into());
+        }
+    }
+
+    info!("Preparing import of {} new users...", body.members.len());
+
+    // Create the accounts and track each club individually
+    let mut new_accounts = HashMap::new();
+    for new_member in &body.members {
+        // Ensure the domain exists
+        let domain = match new_member.email.rsplit_once("@") {
+            None => {
+                return Err(format!(
+                    "Malformed email '{}' for user {}",
+                    new_member.email, new_member.username
+                )
+                .into());
+            }
+            Some((_, domain)) => MaxStr::new(domain.to_string())?,
+        };
+        let club = match clubs.iter().find(|c| c.primary_domain == domain) {
+            None => return Err(format!("No club found for domain: {domain}").into()),
+            Some(club) => club,
+        };
+        if !new_accounts.contains_key(&club.uuid) {
+            new_accounts.insert(club.uuid, Vec::new());
+        }
+
+        // Ensure that passwords are actual bcrypt hashes without the need to verify them
+        if let Err(_) = HashParts::from_str(new_member.hashed_password.to_string().as_str()) {
+            return Err(format!(
+                "User '{}' has password in wrong format, expect bcrypt hash",
+                new_member.username
+            )
+            .into());
+        };
+
+        let new_account = ClubAccount::create_raw(
+            &mut tx,
+            CreateManualClubMember {
+                username: new_member.username.clone(),
+                display_name: new_member.display_name.clone(),
+                hashed_password: new_member.hashed_password.clone(),
+                email: new_member.email.clone(),
+                club: ForeignModelByField(club.uuid.0),
+            },
+        )
+        .await
+        .map_err(|e| format!("Club {}: user {}: {}", club.name, new_member.username, e))?;
+        new_accounts
+            .get_mut(&club.uuid)
+            .expect("previously just created")
+            .push(new_account);
+    }
+
+    tx.commit().await?;
+    info!(
+        "Imported {} new accounts, not saved yet, preparing mailcow app password setup",
+        new_accounts.len()
+    );
+
+    let mut ongoing_jobs = vec![];
+    for club in &clubs {
+        if !club.use_xauth {
+            for new_account in new_accounts.get(&club.uuid).expect("just created earlier") {
+                // TODO: access to mailcow galvyn module also without the web server possible?
+                ongoing_jobs.push(Mailcow::global().create_app_password(new_account.email.clone()));
+                tokio::time::sleep(Duration::from_millis(200)).await; // slightly avoid overloading
+            }
+        }
+    }
+    info!(
+        "Waiting for the completion of {} background jobs",
+        ongoing_jobs.len()
+    );
+    while let Some(job) = ongoing_jobs.pop() {
+        if !job.is_finished() {
+            ongoing_jobs.push(job);
+            info!(
+                "Waiting for the completion of {} background jobs",
+                ongoing_jobs.len()
+            );
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    Ok(())
+}
+
+/// File format for bulk imports of existing users
+#[derive(Debug, Deserialize)]
+pub struct ImportBody {
+    members: Vec<ImportUser>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ImportUser {
+    username: MaxStr<255>,
+    display_name: MaxStr<255>,
+    hashed_password: MaxStr<255>,
+    email: MaxStr<255>,
+}

--- a/webserver/src/utils/import.rs
+++ b/webserver/src/utils/import.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use bcrypt::HashParts;
 use galvyn::core::Module;
-use galvyn::rorm::db::transaction::Transaction;
+use galvyn::rorm::Database;
 use galvyn::rorm::fields::types::MaxStr;
 use galvyn::rorm::prelude::ForeignModelByField;
 use serde::Deserialize;
@@ -23,8 +23,11 @@ use crate::modules::mailcow::Mailcow;
 ///
 /// All clubs must exist for every user that is imported through this endpoint.
 /// If a user that should be imported here can not be matched to an existing club,
-/// the import is aborted. It expects the galvyn registry to be available with Mailcow module.
-pub async fn import_data(mut tx: Transaction, body: ImportBody) -> Result<(), Box<dyn Error>> {
+/// the import is aborted.
+///
+/// It expects the galvyn registry to be available with Database and Mailcow modules.
+pub async fn import_data(body: ImportBody) -> Result<(), Box<dyn Error>> {
+    let mut tx = Database::global().start_transaction().await?;
     let clubs = Club::find_all(&mut tx).await?;
 
     // Ensure no duplicate usernames or email addresses across all existing members
@@ -86,12 +89,10 @@ pub async fn import_data(mut tx: Transaction, body: ImportBody) -> Result<(), Bo
             None => return Err(format!("No club found for domain: {domain}").into()),
             Some(club) => club,
         };
-        if !new_accounts.contains_key(&club.uuid) {
-            new_accounts.insert(club.uuid, Vec::new());
-        }
+        new_accounts.entry(club.uuid).or_insert_with(Vec::new);
 
         // Ensure that passwords are actual bcrypt hashes without the need to verify them
-        if let Err(_) = HashParts::from_str(new_member.hashed_password.to_string().as_str()) {
+        if HashParts::from_str(new_member.hashed_password.to_string().as_str()).is_err() {
             return Err(format!(
                 "User '{}' has password in wrong format, expect bcrypt hash",
                 new_member.username
@@ -111,6 +112,7 @@ pub async fn import_data(mut tx: Transaction, body: ImportBody) -> Result<(), Bo
         )
         .await
         .map_err(|e| format!("Club {}: user {}: {}", club.name, new_member.username, e))?;
+        #[allow(clippy::expect_used)]
         new_accounts
             .get_mut(&club.uuid)
             .expect("previously just created")
@@ -122,21 +124,22 @@ pub async fn import_data(mut tx: Transaction, body: ImportBody) -> Result<(), Bo
     tx.commit().await?;
     info!(
         "Imported {} new accounts, now preparing mailcow app password setup, do not quit...",
-        new_accounts.len()
+        new_accounts.values().map(|v| v.len()).sum::<usize>()
     );
 
     const MAX_WORKERS: usize = 8;
 
-    // Using a semaphore for limiting max amount of concurrent workers
+    // Using a semaphore for limiting max number of concurrent workers
     let mut join_set = tokio::task::JoinSet::new();
     let semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_WORKERS));
     for club in &clubs {
         if !club.use_xauth {
-            for new_account in new_accounts.get(&club.uuid).expect("just created earlier") {
+            for new_account in new_accounts.get(&club.uuid).unwrap_or(&Vec::new()) {
                 let semaphore = semaphore.clone();
                 let email = new_account.email.clone();
                 join_set.spawn(async move {
-                    let _permit = semaphore.acquire().await.expect("never closed");
+                    #[allow(clippy::expect_used)]
+                    let permit = semaphore.acquire().await.expect("never closed");
                     let handle = Mailcow::global().create_app_password(email.clone());
                     match handle.join().await {
                         Ok(_) => (),
@@ -147,7 +150,7 @@ pub async fn import_data(mut tx: Transaction, body: ImportBody) -> Result<(), Bo
                             "Failed to complete a job to update app password, continuing anyway..."
                         ),
                     };
-                    drop(_permit); // automatically, but for clarity
+                    drop(permit); // automatically, but for clarity
                 });
             }
         }
@@ -157,7 +160,7 @@ pub async fn import_data(mut tx: Transaction, body: ImportBody) -> Result<(), Bo
     let total_jobs = join_set.len();
     let mut completed = 0;
     let chunk = (total_jobs / 10).max(1);
-    while let Some(_) = join_set.join_next().await {
+    while join_set.join_next().await.is_some() {
         completed += 1;
         if completed % chunk == 0 {
             info!(

--- a/webserver/src/utils/import.rs
+++ b/webserver/src/utils/import.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use bcrypt::HashParts;
 use galvyn::core::Module;
 use galvyn::rorm::Database;
+use galvyn::rorm::db::transaction::Transaction;
 use galvyn::rorm::fields::types::MaxStr;
 use galvyn::rorm::prelude::ForeignModelByField;
 use serde::Deserialize;
@@ -17,6 +18,7 @@ use tracing::warn;
 use crate::models::account::ClubAccount;
 use crate::models::account::CreateManualClubMember;
 use crate::models::club::Club;
+use crate::models::club::ClubUuid;
 use crate::modules::mailcow::Mailcow;
 
 /// Import users from a JSON payload
@@ -30,18 +32,42 @@ pub async fn import_data(body: ImportBody) -> Result<(), Box<dyn Error>> {
     let mut tx = Database::global().start_transaction().await?;
     let clubs = Club::find_all(&mut tx).await?;
 
-    // Ensure no duplicate usernames or email addresses across all existing members
-    // (it would still break later if collided with the name of a superadmin)
-    for club in &clubs {
+    info!("Validating input data...");
+    validate_club_members(&body.members, &clubs, &mut tx).await?;
+
+    info!("Preparing import of {} new users...", body.members.len());
+    let new_accounts = prepare_db_import(&body.members, &clubs, &mut tx).await?;
+
+    // Committing the transaction here is required due to the implementation of the
+    // app_password worker, simply hope for the best and that all jobs complete
+    tx.commit().await?;
+    info!(
+        "Imported {} new accounts, now preparing mailcow app password setup, do not quit...",
+        new_accounts.values().map(|v| v.len()).sum::<usize>()
+    );
+
+    setup_mailcow_app_passwords(&new_accounts, &clubs).await?;
+    info!("Completed import");
+    Ok(())
+}
+
+/// Ensure no duplicate usernames or email addresses across all existing members
+/// (it would still break later if collided with the name of a superadmin)
+async fn validate_club_members(
+    new_members: &[ImportUser],
+    clubs: &[Club],
+    tx: &mut Transaction,
+) -> Result<(), Box<dyn Error>> {
+    for club in clubs {
         let members = club
-            .members_page(&mut tx, u32::MAX as u64, 0, None)
+            .members_page(&mut *tx, u32::MAX as u64, 0, None)
             .await?
             .items;
 
         let mut email_taken = vec![];
         let mut username_taken = vec![];
         for club_member in &members {
-            for new_member in &body.members {
+            for new_member in new_members {
                 if club_member.email == new_member.email {
                     email_taken.push(club_member.email.clone());
                 }
@@ -68,12 +94,20 @@ pub async fn import_data(body: ImportBody) -> Result<(), Box<dyn Error>> {
             .into());
         }
     }
+    Ok(())
+}
 
-    info!("Preparing import of {} new users...", body.members.len());
-
+/// Create the new member accounts in the database with some additional
+/// validation, but without committing the transaction. The result is a map
+/// of clubs and newly created members in that club.
+async fn prepare_db_import(
+    new_members: &[ImportUser],
+    clubs: &[Club],
+    tx: &mut Transaction,
+) -> Result<HashMap<ClubUuid, Vec<ClubAccount>>, Box<dyn Error>> {
     // Create the accounts and track each club individually
     let mut new_accounts = HashMap::new();
-    for new_member in &body.members {
+    for new_member in new_members {
         // Ensure the domain exists
         let domain = match new_member.email.rsplit_once("@") {
             None => {
@@ -101,7 +135,7 @@ pub async fn import_data(body: ImportBody) -> Result<(), Box<dyn Error>> {
         };
 
         let new_account = ClubAccount::create_raw(
-            &mut tx,
+            &mut *tx,
             CreateManualClubMember {
                 username: new_member.username.clone(),
                 display_name: new_member.display_name.clone(),
@@ -118,21 +152,23 @@ pub async fn import_data(body: ImportBody) -> Result<(), Box<dyn Error>> {
             .expect("previously just created")
             .push(new_account);
     }
+    Ok(new_accounts)
+}
 
-    // Committing the transaction here is required due to the implementation of the
-    // app_password worker, simply hope for the best and that all jobs complete
-    tx.commit().await?;
-    info!(
-        "Imported {} new accounts, now preparing mailcow app password setup, do not quit...",
-        new_accounts.values().map(|v| v.len()).sum::<usize>()
-    );
-
+/// For each newly created account, configure a specific mailcow app password with
+/// the plain password of the user so that the login via POP/IMAP/SMTP works with
+/// the same password as the web login by default. Note that the password is always
+/// hashed (bcrypt), but that mailcow accepts hashed app passwords to make that work.
+async fn setup_mailcow_app_passwords(
+    new_accounts: &HashMap<ClubUuid, Vec<ClubAccount>>,
+    clubs: &[Club],
+) -> Result<(), Box<dyn Error>> {
     const MAX_WORKERS: usize = 8;
 
     // Using a semaphore for limiting max number of concurrent workers
     let mut join_set = tokio::task::JoinSet::new();
     let semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_WORKERS));
-    for club in &clubs {
+    for club in clubs {
         if !club.use_xauth {
             for new_account in new_accounts.get(&club.uuid).unwrap_or(&Vec::new()) {
                 let semaphore = semaphore.clone();
@@ -172,7 +208,6 @@ pub async fn import_data(body: ImportBody) -> Result<(), Box<dyn Error>> {
         }
     }
 
-    info!("Completed import");
     Ok(())
 }
 

--- a/webserver/src/utils/mod.rs
+++ b/webserver/src/utils/mod.rs
@@ -1,4 +1,5 @@
 //! Utility modules
 
+pub mod import;
 pub mod links;
 pub mod worker;

--- a/webserver/src/utils/worker.rs
+++ b/webserver/src/utils/worker.rs
@@ -33,6 +33,11 @@ pub struct WorkerHandle<T> {
     worker: PhantomData<T>,
 }
 impl<T> WorkerHandle<T> {
+    /// Check if the worker is finished
+    pub fn is_finished(&self) -> bool {
+        self.join_handle.is_finished()
+    }
+
     /// Abort the worker
     pub fn abort(&self) {
         self.join_handle.abort();

--- a/webserver/src/utils/worker.rs
+++ b/webserver/src/utils/worker.rs
@@ -4,6 +4,8 @@
 
 use std::marker::PhantomData;
 
+use tokio::task::JoinError;
+
 /// The `Worker` trait provides a blueprint for creating and managing asynchronous workers.
 /// Each worker must implement the `run` method, defining the worker's processing logic.
 ///
@@ -33,9 +35,9 @@ pub struct WorkerHandle<T> {
     worker: PhantomData<T>,
 }
 impl<T> WorkerHandle<T> {
-    /// Check if the worker is finished
-    pub fn is_finished(&self) -> bool {
-        self.join_handle.is_finished()
+    /// Await the completion of the background job
+    pub async fn join(self) -> Result<(), JoinError> {
+        self.join_handle.await
     }
 
     /// Abort the worker


### PR DESCRIPTION
Add import via local JSON file through a new CLI command.
The file format is explained in the rust file.
The loop for the data import is async using a semaphore to limit the workers.
The database transaction completes before any app worker jobs are started, thus we rely on the executor to not simply quit the program mid-import to avoid data issues.