### PR TITLE
Allow sign-in via club_user email address if no username was found

### DIFF
--- a/webserver/src/http/handler_auth/auth/mod.rs
+++ b/webserver/src/http/handler_auth/auth/mod.rs
@@ -20,6 +20,7 @@ use crate::http::extractors::session_user::SessionUser;
 use crate::http::handler_auth::auth::schema::AuthQuery;
 use crate::http::handler_auth::auth::schema::SignInRequest;
 use crate::models::account::Account;
+use crate::models::account::ClubAccount;
 use crate::models::oidc_provider::CreateOidcAuthenticationToken;
 use crate::models::oidc_provider::OidcAuthenticationToken;
 use crate::models::oidc_provider::OidcClient;
@@ -99,7 +100,13 @@ pub async fn sign_in(
 ) -> ApiResult<()> {
     let mut tx = Database::global().start_transaction().await?;
 
-    let Some(account) = Account::get_by_username(&mut tx, &username).await? else {
+    let lookup_result = match Account::get_by_username(&mut tx, &username).await? {
+        Some(account) => Some(account),
+        None => ClubAccount::get_by_email(&mut tx, &username)
+            .await?
+            .map(Account::ClubMember),
+    };
+    let Some(account) = lookup_result else {
         // dummy bcrypt to not allow timing attacks for username enumeration
         bcrypt::verify(
             "foo",


### PR DESCRIPTION
It will first attempt any username on any normal account model just as before.

But this will allow normal users to login successfully via both username `MyFirstName.MyLastName` as well as email address `my.name@club.tld`. This will be a lot less confusing for normal users, because they currently would login with their email address in the mailcow web UI (formerly SOGo). If they now need to login with username, they may not be able to do that because they may not even know their username: while it is first.last by default, this is not always the case (especially for non-natural persons, like associations). But they do know their email address because that's what they currently use for their login! So this will reduce load on the help desk to explain and resolve the issue.