### PR TITLE
Fixed race condition of creation of app password from password resets

### DIFF
--- a/webserver/src/http/handler_frontend/credential_reset/handler_common.rs
+++ b/webserver/src/http/handler_frontend/credential_reset/handler_common.rs
@@ -108,17 +108,22 @@ pub async fn reset_password(
     account.set_password(&mut tx, &password).await?;
     CredentialReset::delete_by_uuid(&mut tx, reset.uuid).await?;
 
+    let mut app_password_mailbox = None;
     if let Account::ClubMember(ref member) = account {
         let club = Club::find_by_uuid(&mut tx, member.club)
             .await?
             .ok_or(ApiError::server_error("Club should exist"))?;
 
         if !club.use_xauth {
-            Mailcow::global().create_app_password(member.email.clone());
+            app_password_mailbox = Some(member.email.clone());
         }
     }
 
     tx.commit().await?;
+
+    if let Some(member_mailbox) = app_password_mailbox {
+        Mailcow::global().create_app_password(member_mailbox);
+    }
 
     Ok(ApiJson(FormResult::ok(())))
 }
@@ -171,17 +176,22 @@ pub async fn reset_password_by_uuid(
     account.set_password(&mut tx, &password).await?;
     CredentialReset::delete_by_uuid(&mut tx, reset.uuid).await?;
 
+    let mut app_password_mailbox = None;
     if let Account::ClubMember(ref member) = account {
         let club = Club::find_by_uuid(&mut tx, member.club)
             .await?
             .ok_or(ApiError::server_error("Club should exist"))?;
 
         if !club.use_xauth {
-            Mailcow::global().create_app_password(member.email.clone());
+            app_password_mailbox = Some(member.email.clone());
         }
     }
 
     tx.commit().await?;
+
+    if let Some(member_mailbox) = app_password_mailbox {
+        Mailcow::global().create_app_password(member_mailbox);
+    }
 
     Ok(ApiJson(FormResult::ok(())))
 }

--- a/webserver/src/http/handler_frontend/me/handler_common.rs
+++ b/webserver/src/http/handler_frontend/me/handler_common.rs
@@ -153,17 +153,22 @@ pub async fn set_password(
     }
     account.set_password(&mut tx, &password).await?;
 
-    if let Account::ClubMember(ref account) = account {
-        let club = Club::find_by_uuid(&mut tx, account.club)
+    let mut app_password_mailbox = None;
+    if let Account::ClubMember(ref member) = account {
+        let club = Club::find_by_uuid(&mut tx, member.club)
             .await?
             .ok_or(ApiError::server_error("Club should exist"))?;
 
         if !club.use_xauth {
-            Mailcow::global().create_app_password(account.email.clone());
+            app_password_mailbox = Some(member.email.clone());
         }
     }
 
     tx.commit().await?;
+
+    if let Some(member_mailbox) = app_password_mailbox {
+        Mailcow::global().create_app_password(member_mailbox);
+    }
 
     // Invalidate the current session after a password change
     session.remove::<SessionUser>(SESSION_USER).await?;


### PR DESCRIPTION
Addresses #122 

I am not sure if the behavior in `webserver/src/http/handler_auth/token/mod.rs` is correctly implemented. It should be looked at.
This does not yet fix #122 entirely without that.